### PR TITLE
Using a buffered response as it is in Handy project

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -1,0 +1,56 @@
+package trama
+
+import (
+	"bytes"
+	"net/http"
+)
+
+type BufferedResponseWriter struct {
+	flushed bool
+	status  int
+	wire    http.ResponseWriter
+	Body    *bytes.Buffer
+}
+
+func NewBufferedResponseWriter(w http.ResponseWriter) *BufferedResponseWriter {
+	return &BufferedResponseWriter{
+		Body: new(bytes.Buffer),
+		wire: w,
+	}
+}
+
+// Header returns the response headers.
+func (rw *BufferedResponseWriter) Header() http.Header {
+	return rw.wire.Header()
+}
+
+// Write always succeeds and writes to rw.Body, if not nil.
+func (rw *BufferedResponseWriter) Write(buf []byte) (int, error) {
+	return rw.Body.Write(buf)
+}
+
+func (rw *BufferedResponseWriter) Status() int {
+	if rw.status == 0 {
+		return http.StatusOK
+	}
+	return rw.status
+}
+
+func (rw *BufferedResponseWriter) WriteHeader(code int) {
+	rw.status = code
+}
+
+func (rw *BufferedResponseWriter) Flush() {
+	if rw.status == 0 {
+		rw.WriteHeader(http.StatusOK)
+	}
+
+	if !rw.flushed {
+		rw.wire.WriteHeader(rw.status)
+	}
+
+	rw.wire.Write(rw.Body.Bytes())
+	rw.Body.Reset()
+
+	rw.flushed = true
+}

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -1,0 +1,67 @@
+package trama
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var (
+	rw = NewBufferedResponseWriter(httptest.NewRecorder())
+)
+
+func TestResponseWriterCreation(t *testing.T) {
+	if rw.Body == nil {
+		t.Fatal("body should not be nil")
+	}
+
+	if rw.wire == nil {
+		t.Fatal("wire should not be nil")
+	}
+
+	if rw.Header() == nil {
+		t.Fatal("header should not be nil")
+	}
+}
+
+func TestResponseWriterModification(t *testing.T) {
+	rw.Header().Add("X-Test", "X")
+	if rw.Header().Get("X-Test") != "X" {
+		t.Fatal("invalid header value")
+	}
+
+	data := []byte("test")
+	i, err := rw.Write(data)
+	if i != len(data) || err != nil {
+		t.Fatal("error writing data on the writer")
+	}
+
+	if !bytes.Equal(rw.Body.Bytes(), data) {
+		t.Fatal("invalid body data")
+	}
+
+	rw.WriteHeader(http.StatusTeapot)
+	if rw.Status() != http.StatusTeapot {
+		t.Fatal("invalid http status code")
+	}
+}
+
+func TestResponseWriterFlushing(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewBufferedResponseWriter(rec)
+	data := []byte("test")
+	rw.Write(data)
+	rw.Flush()
+	if rw.Status() != http.StatusOK {
+		t.Fatal("first call to flush should implicitly set status 'ok'")
+	}
+
+	if !bytes.Equal(rec.Body.Bytes(), data) {
+		t.Fatal("data not sent on the wire")
+	}
+
+	if rw.Body.Len() != 0 {
+		t.Fatal("body not reseted after flush")
+	}
+}

--- a/responses.go
+++ b/responses.go
@@ -6,33 +6,6 @@ import (
 	"path"
 )
 
-type responseWriter struct {
-	http.ResponseWriter
-	status  int
-	written bool
-}
-
-func (w *responseWriter) Write(b []byte) (int, error) {
-	if !w.written {
-		// note: the first call to Write will trigger an
-		// implicit WriteHeader(http.StatusOK).
-		if w.status > 0 {
-			w.ResponseWriter.WriteHeader(w.status)
-		}
-	}
-
-	w.written = true
-	return w.ResponseWriter.Write(b)
-}
-
-func (w *responseWriter) WriteHeader(s int) {
-	w.status = s
-}
-
-func (w *responseWriter) Status() int {
-	return w.status
-}
-
 type Response interface {
 	SetTemplateGroup(name string)
 	SetCookie(cookie *http.Cookie)
@@ -48,7 +21,7 @@ type webResponse struct {
 	currentTemplateGroup string
 	templates            TemplateGroupSet
 	written              bool
-	responseWriter       http.ResponseWriter
+	responseWriter       *BufferedResponseWriter
 	request              *http.Request
 	log                  func(error)
 }


### PR DESCRIPTION
Sometimes we need to known in the interceptor what was written in the wire to take a decision of what to do in the after-interceptor. As an example we have the database transaction interceptor, that commits or rolls back depending on the returning HTTP status code.

This is already a feature in the Handy project.