### PR TITLE
Make it possible to retrieve the template name

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -80,7 +80,7 @@ func (a adapter) serveHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (a adapter) serveWeb(w http.ResponseWriter, r *http.Request) {
 	response := &webResponse{
-		responseWriter: NewBufferedResponseWriter(w),
+		responseWriter: w,
 		request:        r,
 		templates:      a.templates,
 		log:            a.log,
@@ -113,7 +113,6 @@ write:
 	}
 
 	response.write()
-	response.responseWriter.Flush()
 }
 
 func (a adapter) serveAJAX(rw http.ResponseWriter, r *http.Request) {

--- a/responses.go
+++ b/responses.go
@@ -21,9 +21,13 @@ type webResponse struct {
 	currentTemplateGroup string
 	templates            TemplateGroupSet
 	written              bool
-	responseWriter       *BufferedResponseWriter
+	responseWriter       http.ResponseWriter
 	request              *http.Request
 	log                  func(error)
+}
+
+func (r *webResponse) TemplateName() string {
+	return r.templateName
 }
 
 func (r *webResponse) SetTemplateGroup(name string) {


### PR DESCRIPTION
Make it possible to retrieve the template name so we can decide in the after interceptor what can we do in some situations (depending if it was an error page or not)